### PR TITLE
Add 1D tight-binding solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # hello_world
-just started
+
+This repository contains a simple C++ program to calculate the eigenvalues of a 1D tight binding Hamiltonian with periodic boundary conditions.
+
+## Building
+
+Compile the program using a C++11 compatible compiler:
+
+```bash
+g++ -std=c++11 -o tight_binding tight_binding.cpp
+```
+
+## Usage
+
+Run the executable and provide the number of lattice sites `N`, hopping parameter `t`, and onsite energy `epsilon`:
+
+```bash
+./tight_binding N t epsilon
+```
+
+For example, to compute energies for a 4-site chain with hopping `t=1` and zero onsite energy:
+
+```bash
+./tight_binding 4 1.0 0.0
+```
+
+The output will list the eigenvalues of the system.

--- a/tight_binding.cpp
+++ b/tight_binding.cpp
@@ -1,0 +1,29 @@
+#include <iostream>
+#include <vector>
+#include <cmath>
+#include <cstdlib>
+
+int main(int argc, char* argv[]) {
+    if (argc < 4) {
+        std::cout << "Usage: " << argv[0] << " N t epsilon" << std::endl;
+        return 1;
+    }
+    int N = std::atoi(argv[1]);
+    double t = std::atof(argv[2]);
+    double epsilon = std::atof(argv[3]);
+
+    std::vector<double> energies;
+    energies.reserve(N);
+    for (int k = 0; k < N; ++k) {
+        double kappa = 2.0 * M_PI * k / N;
+        double energy = epsilon + 2.0 * t * std::cos(kappa);
+        energies.push_back(energy);
+    }
+
+    std::cout << "Eigenvalues:" << std::endl;
+    for (int i = 0; i < N; ++i) {
+        std::cout << energies[i] << std::endl;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add C++ program `tight_binding.cpp` to compute eigenvalues for a 1D tight-binding lattice
- document build and usage instructions in README

## Testing
- `make test` *(fails: No rule to make target)*
- `python3 -m pytest` *(no tests found)*
- `cargo test` *(fails: could not find `Cargo.toml`)*
- `go test ./...` *(fails: directory prefix does not contain main module)*
- `npm test` *(fails: could not read `package.json`)*
- `mvn -q test` *(fails: command not found)*
- `python3 -m unittest` *(ran 0 tests)*

------
https://chatgpt.com/codex/tasks/task_e_683f8822e970833281bb93b7fa192473